### PR TITLE
DeleteToken now returns Builder similar to other sdk calls

### DIFF
--- a/src/GlobalPayments.Api/PaymentMethods/Credit.cs
+++ b/src/GlobalPayments.Api/PaymentMethods/Credit.cs
@@ -137,20 +137,13 @@ namespace GlobalPayments.Api.PaymentMethods {
         /// Deletes the token associated with the current card object
         /// </summary>
         /// <returns>boolean value indicating success/failure</returns>
-        public bool DeleteToken() {
+        public ManagementBuilder DeleteToken() {
             if (string.IsNullOrEmpty(Token)) {
                 throw new BuilderException("Token cannot be null");
             }
 
-            try {
-                new ManagementBuilder(TransactionType.TokenDelete)
-                    .WithPaymentMethod(this)
-                    .Execute();
-                return true;
-            }
-            catch (ApiException) {
-                return false;
-            }
+	        return new ManagementBuilder(TransactionType.TokenDelete)
+                    .WithPaymentMethod(this);
         }
     }
 

--- a/src/GlobalPayments.Api/PaymentMethods/PaymentInterfaces.cs
+++ b/src/GlobalPayments.Api/PaymentMethods/PaymentInterfaces.cs
@@ -64,8 +64,8 @@ namespace GlobalPayments.Api.PaymentMethods
         string Token { get; set; }
         string Tokenize();
         bool UpdateTokenExpiry();
-        bool DeleteToken();
-    }
+		ManagementBuilder DeleteToken();
+	}
 
     interface IVerifiable {
         AuthorizationBuilder Verify();

--- a/tests/GlobalPayments.Api.Tests/Portico/PorticoTokenManagement.cs
+++ b/tests/GlobalPayments.Api.Tests/Portico/PorticoTokenManagement.cs
@@ -49,7 +49,7 @@ namespace GlobalPayments.Api.Tests.Portico {
             var token = new CreditCardData {
                 Token = _token
             };
-            Assert.IsTrue(token.DeleteToken());
+            token.DeleteToken().Execute();
 
             try {
                 token.Verify().Execute();


### PR DESCRIPTION
Changing DeleteToken to return a Builder so that the consumer of the sdk can call execute with the config of their choice.