### PR TITLE
Update ServicesContainer.cs

### DIFF
--- a/src/GlobalPayments.Api/ServicesContainer.cs
+++ b/src/GlobalPayments.Api/ServicesContainer.cs
@@ -38,11 +38,13 @@ namespace GlobalPayments.Api {
                 return _secure3dProviders[version];
             }
             else if (version.Equals(Secure3dVersion.Any)) {
-                var provider = _secure3dProviders[Secure3dVersion.Two];
-                if (provider == null) {
-                    provider = _secure3dProviders[Secure3dVersion.One];
+                if (_secure3dProviders.ContainsKey(Secure3dVersion.Two)) {
+                    return _secure3dProviders[Secure3dVersion.Two];
                 }
-                return provider;
+                else if (_secure3dProviders.ContainsKey(Secure3dVersion.One))
+                {
+                    return _secure3dProviders[Secure3dVersion.One];
+                }
             }
             return null;
         }


### PR DESCRIPTION
Bug fix where exception was thrown if Secure3dVersion.Two key didn't exist in the _secure3dProviders dictionary.
Fix ensures provider selection correctly falls back to attempting Secure3dVersion.One if Secure3dVersion.Two does not exist.
Returns null if no Secure3dVersion supported to be handled by calling method.