### PR TITLE
Fixes globalpayments/dotnet-sdk#30

### DIFF
--- a/src/GlobalPayments.Api/Entities/RecurringEntity.cs
+++ b/src/GlobalPayments.Api/Entities/RecurringEntity.cs
@@ -23,7 +23,7 @@ namespace GlobalPayments.Api.Entities {
         /// </summary>
         /// <returns>TResult</returns>
         public TResult Create(string configName = "default") {
-            return RecurringService.Create(this as TResult);
+            return RecurringService.Create(this as TResult, configName);
         }
 
         /// <summary>
@@ -31,9 +31,9 @@ namespace GlobalPayments.Api.Entities {
         /// </summary>
         /// <param name="force">Indicates if the deletion should be forced</summary>
         /// <exception cref="ApiException">Thrown when the record cannot be deleted.</exception>
-        public void Delete(bool force = false) {
+        public void Delete(bool force = false, string configName = "default") {
             try {
-                RecurringService.Delete(this as TResult, force);
+                RecurringService.Delete(this as TResult, force, configName);
             }
             catch (ApiException exc) {
                 throw new ApiException("Failed to delete record, see inner exception for more details", exc);

--- a/src/GlobalPayments.Api/Services/RecurringService.cs
+++ b/src/GlobalPayments.Api/Services/RecurringService.cs
@@ -5,26 +5,26 @@ using GlobalPayments.Api.Entities;
 
 namespace GlobalPayments.Api.Services {
     public class RecurringService {
-        public static T Create<T>(T entity) where T : class, IRecurringEntity {
-            var response = new RecurringBuilder<T>(TransactionType.Create, entity).Execute();
+        public static T Create<T>(T entity, string configName = "default") where T : class, IRecurringEntity {
+            var response = new RecurringBuilder<T>(TransactionType.Create, entity).Execute(configName);
             return response as T;
         }
 
-        public static T Delete<T>(T entity, bool force = false) where T : class, IRecurringEntity {
-            var response = new RecurringBuilder<T>(TransactionType.Delete, entity).Execute();
+        public static T Delete<T>(T entity, bool force = false, string configName = "default") where T : class, IRecurringEntity {
+            var response = new RecurringBuilder<T>(TransactionType.Delete, entity).Execute(configName);
             return response as T;
         }
 
-        public static T Edit<T>(T entity) where T : class, IRecurringEntity {
-            var response = new RecurringBuilder<T>(TransactionType.Edit, entity).Execute();
+        public static T Edit<T>(T entity, string configName = "default") where T : class, IRecurringEntity {
+            var response = new RecurringBuilder<T>(TransactionType.Edit, entity).Execute(configName);
             return response as T;
         }
 
-        public static T Get<T>(string key) where T : class, IRecurringEntity {
+        public static T Get<T>(string key, string configName = "default") where T : class, IRecurringEntity {
             var entity = Activator.CreateInstance<T>() as IRecurringEntity;
             entity.Key = key;
 
-            var response = new RecurringBuilder<T>(TransactionType.Fetch, entity).Execute();
+            var response = new RecurringBuilder<T>(TransactionType.Fetch, entity).Execute(configName);
             return response as T;
         }
 


### PR DESCRIPTION
This fix passes in the config name to all the methods requiring it in the
Recurring Service and related entities. This allows a config name other than
"default"