### PR TITLE
Fix for issue #37

### DIFF
--- a/src/GlobalPayments.Api/Services/HostedService.cs
+++ b/src/GlobalPayments.Api/Services/HostedService.cs
@@ -8,9 +8,9 @@ namespace GlobalPayments.Api.Services {
     public class HostedService {
         GpEcomConfig _config;
 
-        public HostedService(GpEcomConfig config) {
+        public HostedService(GpEcomConfig config, string configName = "default") {
             _config = config;
-            ServicesContainer.ConfigureService(config);
+            ServicesContainer.ConfigureService(config, configName);
         }
 
         public AuthorizationBuilder Authorize(decimal? amount = null) {


### PR DESCRIPTION
Added default configName property to HostedService constructor which is passed to ServicesContainer.ConfigureService().  Prevents overwriting of 'default' configName in multi-thread environments and resulting race condition.