### PR TITLE
Fixing WebProxy option for all HttpClient consumers

### DIFF
--- a/src/GlobalPayments.Api/Gateways/BillPayProvider.cs
+++ b/src/GlobalPayments.Api/Gateways/BillPayProvider.cs
@@ -2,6 +2,7 @@
 using GlobalPayments.Api.Entities;
 using GlobalPayments.Api.Entities.Billing;
 using GlobalPayments.Api.Gateways.BillPay;
+using System.Net;
 
 namespace GlobalPayments.Api.Gateways {
     internal class BillPayProvider: IBillingProvider, IPaymentGateway, IRecurringService {
@@ -18,6 +19,8 @@ namespace GlobalPayments.Api.Gateways {
         public int Timeout { get; set; }
 
         public string ServiceUrl { get; set; }
+
+        public IWebProxy WebProxy { get; set; }
 
         /// <summary>
         /// Invokes a request against the BillPay gateway using the AuthorizationBuilder

--- a/src/GlobalPayments.Api/ServiceConfigs/BillPayConfig.cs
+++ b/src/GlobalPayments.Api/ServiceConfigs/BillPayConfig.cs
@@ -22,7 +22,8 @@ namespace GlobalPayments.Api {
                 },
                 ServiceUrl = ServiceUrl ?? ServiceEndpoints.BILLPAY_PRODUCTION,
                 Timeout = Timeout,
-                IsBillDataHosted = UseBillRecordlookup
+                IsBillDataHosted = UseBillRecordlookup,
+                WebProxy = WebProxy
             };
 
             services.GatewayConnector = gateway;

--- a/src/GlobalPayments.Api/ServiceConfigs/Gateways/GeniusConfig.cs
+++ b/src/GlobalPayments.Api/ServiceConfigs/Gateways/GeniusConfig.cs
@@ -37,7 +37,8 @@ namespace GlobalPayments.Api {
                 RegisterNumber = RegisterNumber,
                 TerminalId = TerminalId,
                 Timeout = Timeout,
-                ServiceUrl = ServiceUrl
+                ServiceUrl = ServiceUrl,
+                WebProxy = WebProxy
             };
 
             services.GatewayConnector = gateway;

--- a/src/GlobalPayments.Api/ServiceConfigs/Gateways/GpEcomConfig.cs
+++ b/src/GlobalPayments.Api/ServiceConfigs/Gateways/GpEcomConfig.cs
@@ -73,7 +73,8 @@ namespace GlobalPayments.Api {
                 SharedSecret = SharedSecret,
                 Timeout = Timeout,
                 ServiceUrl = ServiceUrl,
-                HostedPaymentConfig = HostedPaymentConfig
+                HostedPaymentConfig = HostedPaymentConfig,
+                WebProxy = WebProxy
             };
             services.GatewayConnector = gateway;
             services.RecurringConnector = gateway;            
@@ -98,7 +99,8 @@ namespace GlobalPayments.Api {
                     MerchantContactUrl = MerchantContactUrl,
                     MethodNotificationUrl = MethodNotificationUrl,
                     ChallengeNotificationUrl = ChallengeNotificationUrl,
-                    Timeout = Timeout
+                    Timeout = Timeout,
+                    WebProxy = WebProxy
                     //secure3d2.EnableLogging = EnableLogging
                 };
 

--- a/src/GlobalPayments.Api/ServiceConfigs/Gateways/PorticoConfig.cs
+++ b/src/GlobalPayments.Api/ServiceConfigs/Gateways/PorticoConfig.cs
@@ -110,7 +110,8 @@ namespace GlobalPayments.Api {
                 Timeout = Timeout,
                 ServiceUrl = ServiceUrl + "/Hps.Exchange.PosGateway/PosGatewayService.asmx",
                 UniqueDeviceId = UniqueDeviceId,
-                RequestLogger = RequestLogger
+                RequestLogger = RequestLogger,
+                WebProxy = WebProxy
             };
             services.GatewayConnector = gateway;
 
@@ -123,7 +124,8 @@ namespace GlobalPayments.Api {
                 SecretApiKey = SecretApiKey,
                 Timeout = Timeout,
                 ServiceUrl = ServiceUrl + PayPlanEndpoint,
-                RequestLogger = RequestLogger
+                RequestLogger = RequestLogger,
+                WebProxy = WebProxy
             };
             services.RecurringConnector = payplan;
 
@@ -142,7 +144,8 @@ namespace GlobalPayments.Api {
                     TermID = TerminalID,
                     Timeout = Timeout,
                     ServiceUrl = ServiceUrl,
-                    X509CertPath = X509CertificatePath
+                    X509CertPath = X509CertificatePath,
+                    WebProxy = WebProxy
                 };
 
                 services.PayFacProvider = payFac;

--- a/src/GlobalPayments.Api/ServiceConfigs/Gateways/TransitConfig.cs
+++ b/src/GlobalPayments.Api/ServiceConfigs/Gateways/TransitConfig.cs
@@ -29,7 +29,8 @@ namespace GlobalPayments.Api {
                 TransactionKey = TransactionKey,
                 ServiceUrl = ServiceUrl,
                 Timeout = Timeout,
-                RequestLogger = RequestLogger
+                RequestLogger = RequestLogger,
+                WebProxy = WebProxy
             };
 
             services.GatewayConnector = gateway;


### PR DESCRIPTION
The modifications arround the WebProxy option was not done for all HttpClient consumers in the release v1.7.14. These modifications fix this for all HttpClient consumers.