### PR TITLE
Fix signature image width

### DIFF
--- a/src/GlobalPayments.Api/Terminals/PAX/PaxInterface.cs
+++ b/src/GlobalPayments.Api/Terminals/PAX/PaxInterface.cs
@@ -54,7 +54,7 @@ namespace GlobalPayments.Api.Terminals.PAX {
                 ControlCodes.FS,
                 300
             ));
-            var signatureResponse = new SignatureResponse(response);
+            var signatureResponse = new SignatureResponse(response, _controller.DeviceType.Value);
             if (signatureResponse.DeviceResponseCode == "000000")
                 return GetSignatureFile();
             return signatureResponse;

--- a/src/GlobalPayments.Api/Terminals/PAX/Responses/SignatureResponse.cs
+++ b/src/GlobalPayments.Api/Terminals/PAX/Responses/SignatureResponse.cs
@@ -8,29 +8,46 @@ namespace GlobalPayments.Api.Terminals.PAX {
         private DeviceType _deviceType;
 
         public int TotalLength { get; set; }
-        public int ResponseLegth { get; set; }
+        public int ResponseLength { get; set; }
+        public string UnparsedSignature { get; set; }
+
+
 
         public SignatureResponse(byte[] response, DeviceType deviceType = DeviceType.PAX_S300) : base(response, PAX_MSG_ID.A09_RSP_GET_SIGNATURE, PAX_MSG_ID.A21_RSP_DO_SIGNATURE) {
             _deviceType = deviceType;
+            ProcessImage();  // must be called AFTER setting device type
         }
 
         protected override void ParseResponse(BinaryReader br) {
             base.ParseResponse(br);
-
-            if (DeviceResponseCode == "000000" && Command == PAX_MSG_ID.A09_RSP_GET_SIGNATURE) {
+            if (DeviceResponseCode == "000000" && Command == PAX_MSG_ID.A09_RSP_GET_SIGNATURE)
+            {
                 TotalLength = int.Parse(br.ReadToCode(ControlCodes.FS));
-                ResponseLegth = int.Parse(br.ReadToCode(ControlCodes.FS));
+                ResponseLength = int.Parse(br.ReadToCode(ControlCodes.FS));
 
-                var signatureData = br.ReadToCode(ControlCodes.ETX);
+                UnparsedSignature = br.ReadToCode(ControlCodes.ETX);
+            }
 
+        }
+
+        /// <summary>
+        /// call this to convert string data to a BMP image and store it
+        /// </summary>
+        private void ProcessImage()
+        {
+            if (UnparsedSignature != null)
+            {
                 int imageWidth = 150;
-                switch (_deviceType) {
+                switch (_deviceType)
+                {
                     case DeviceType.PAX_PX5:
-                    case DeviceType.PAX_PX7: {
+                    case DeviceType.PAX_PX7:
+                        {
                             imageWidth = 350;
-                        } break;
+                        }
+                        break;
                 }
-                SignatureData = TerminalUtilities.BuildSignatureImage(signatureData, imageWidth);
+                SignatureData = TerminalUtilities.BuildSignatureImage(UnparsedSignature, imageWidth);
             }
         }
     }


### PR DESCRIPTION
When retrieving signature from PAX device with 350 pixel screens, the images get truncated at 150 pixels. 
This change uses the device type to set the width to 350 on some devices. An earlier change attempted to do this, but it failed to work because device type was not available at the right time. 