### PR TITLE
use correct image size when calling PromptForSignature

### DIFF
--- a/src/GlobalPayments.Api/Terminals/PAX/PaxInterface.cs
+++ b/src/GlobalPayments.Api/Terminals/PAX/PaxInterface.cs
@@ -54,7 +54,7 @@ namespace GlobalPayments.Api.Terminals.PAX {
                 ControlCodes.FS,
                 300
             ));
-            var signatureResponse = new SignatureResponse(response);
+            var signatureResponse = new SignatureResponse(response, _controller.DeviceType.Value);
             if (signatureResponse.DeviceResponseCode == "000000")
                 return GetSignatureFile();
             return signatureResponse;


### PR DESCRIPTION
device was not passed to SignatureResponse, so it always defaulted to PAX S300, which has smaller screen size than other models.