### PR TITLE
Fix OpenBanking mapping crash when a scalar field is returned as an array

### DIFF
--- a/src/GlobalPayments.Api/Utils/JsonUtils.cs
+++ b/src/GlobalPayments.Api/Utils/JsonUtils.cs
@@ -132,7 +132,25 @@ namespace GlobalPayments.Api.Utils {
                     else return (T)Convert.ChangeType(value, typeof(T));
                 }
                 catch (InvalidCastException) {
-                    return (T)_dict[name];
+                    var raw = _dict[name];
+                    // Value is already the requested type (e.g. a nested JsonDoc). Original behaviour.
+                    if (raw is T typed) {
+                        return typed;
+                    }
+                    // Gateway sent an array where a scalar was expected, e.g. "created_on": ["..."].
+                    // Collapse to the first convertible element rather than casting the whole
+                    // collection, which would throw a second, uncaught InvalidCastException.
+                    if (raw is IEnumerable<string> collection) {
+                        foreach (var item in collection) {
+                            try {
+                                return (T)Convert.ChangeType(item, typeof(T));
+                            }
+                            catch {
+                                break;
+                            }
+                        }
+                    }
+                    return default(T);
                 }
             }
             return default(T);

--- a/tests/GlobalPayments.Api.Tests/GpEcom/GpEcomOpenBankingMappingTest.cs
+++ b/tests/GlobalPayments.Api.Tests/GpEcom/GpEcomOpenBankingMappingTest.cs
@@ -1,0 +1,60 @@
+using System;
+using GlobalPayments.Api.Entities;
+using GlobalPayments.Api.Mapping;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace GlobalPayments.Api.Tests.GpEcom
+{
+    [TestClass]
+    public class GpEcomOpenBankingMappingTest
+    {
+        // Reproduces the 500 seen on order NSP6640-112730-ANNOB-20260611122832.
+        // The gateway returned created_on as a JSON array. GetValue<DateTime> fails the
+        // Convert.ChangeType, and the catch re-casts the List<string> and throws again.
+        private const string PaymentWithArrayCreatedOn = @"{
+            ""payments"": [
+                {
+                    ""ob_trans_id"": ""YAIIfkmSPGfIzLHkum"",
+                    ""order_id"": ""NSP6640-112730-ANNOB-20260611122832"",
+                    ""amount"": ""780"",
+                    ""currency"": ""GBP"",
+                    ""status"": ""PAID"",
+                    ""created_on"": [""2026-06-11T11:29:35.876""]
+                }
+            ]
+        }";
+
+        [TestMethod]
+        public void MapTransactionSummary_CreatedOnAsArray_DoesNotThrow() {
+            // Before the fix this threw InvalidCastException (List<string> -> DateTime) and surfaced as a 500.
+            var result = OpenBankingMapping.MapReportResponse<PagedResult<TransactionSummary>>(
+                PaymentWithArrayCreatedOn, ReportType.FindBankPayment);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(1, result.Results.Count);
+
+            var summary = result.Results[0];
+            // The rest of the record still maps. The scalar string fields are exact.
+            Assert.AreEqual("YAIIfkmSPGfIzLHkum", summary.TransactionId);
+            Assert.AreEqual("NSP6640-112730-ANNOB-20260611122832", summary.OrderId);
+            Assert.AreEqual("GBP", summary.Currency);
+            Assert.AreEqual("PAID", summary.TransactionStatus);
+            // The arrayed date is recovered on a best-effort basis (first element), so it is populated
+            // rather than left at default. Exact precision is not guaranteed for a malformed array field.
+            Assert.AreNotEqual(default(DateTime), summary.TransactionDate);
+        }
+
+        [TestMethod]
+        public void MapTransactionSummary_CreatedOnAsString_StillMaps() {
+            var raw = PaymentWithArrayCreatedOn.Replace(
+                @"""created_on"": [""2026-06-11T11:29:35.876""]",
+                @"""created_on"": ""2026-06-11T11:29:35.876""");
+
+            var result = OpenBankingMapping.MapReportResponse<PagedResult<TransactionSummary>>(
+                raw, ReportType.FindBankPayment);
+
+            var expected = (DateTime)Convert.ChangeType("2026-06-11T11:29:35.876", typeof(DateTime));
+            Assert.AreEqual(expected, result.Results[0].TransactionDate);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #99. Also resolves #97.

## Problem

`ReportingService.BankPaymentDetail(...).Execute()` can return a 500 that never reaches the caller's `Results`. The crash is in `JsonDoc.GetValue<T>` (`Utils/JsonUtils.cs`), not in the mapping.

When the gateway returns a field as a JSON array where a scalar is expected, `ParseObject` stores it as a `List<string>`. `GetValue<T>` then hits `Convert.ChangeType(List<string>, DateTime)`, which throws `InvalidCastException`. The existing catch runs `return (T)_dict[name]`, casting the list straight to the target type, so it throws a second time and that one is uncaught.

Reported against `created_on`, but it is not specific to that field. Every field in `MapTransactionSummary` reads through `GetValue<T>` and fails the same way if it arrives as an array.

Stack trace from the field report:

- `JsonDoc.GetValue[T]`
- `OpenBankingMapping.MapTransactionSummary`
- `OpenBankingMapping.MapReportResponse[T]`
- `OpenBankingProvider.ProcessReport[T]`
- `ReportBuilder.Execute`

## Change

One method, `JsonDoc.GetValue<T>`. The catch now:

- returns the value when it is already type `T` (the original intent, e.g. a nested `JsonDoc`),
- collapses an array to its first convertible element,
- returns `default(T)` otherwise, instead of re-throwing.

No public API change. The path only runs inside a catch that previously always threw, so the worst case turns a crash into a value or a `default(T)`.

## Tests

`GpEcomOpenBankingMappingTest`, two cases:

- `created_on` as an array. Throws on current master, passes here.
- `created_on` as a plain string. Guards the normal path, which stays exact.

Verified red then green: reverting the `JsonUtils.cs` change makes the array test fail with the exact reported exception, `InvalidCastException: Unable to cast object of type 'System.Collections.Generic.List1[System.String]' to type 'System.DateTime'`.

## Note for triage

Re-running the report later returns the transaction's current state, which is scalar, so it looks unreproducible. The payload that failed was the one from the original callback, not a fresh query. To confirm the live trigger, pull the raw stored callback JSON for the transaction rather than re-querying it.
